### PR TITLE
Trimmed Binary & Output Properties

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,14 @@ jobs:
           chmod +x dotnetastgen-linux-arm
           chmod +x dotnetastgen-macos
           chmod +x dotnetastgen-macos-arm
+      - name: Compress all executables
+        run: |
+          zip dotnetastgen-linux.zip dotnetastgen-linux
+          zip dotnetastgen-linux-arm.zip  dotnetastgen-linux-arm
+          zip dotnetastgen-macos.zip  dotnetastgen-macos
+          zip dotnetastgen-macos-arm.zip  dotnetastgen-macos-arm
+          zip dotnetastgen-win.zip dotnetastgen-win.exe
+          zip dotnetastgen-win-arm.zip dotnetastgen-win-arm.exe
       - name: Set next release version
         id: taggerFinal
         uses: anothrNick/github-tag-action@1.61.0
@@ -69,9 +77,9 @@ jobs:
         with:
           tag_name: ${{ steps.taggerDryRun.outputs.new_tag }}
           files: |
-            dotnetastgen-linux
-            dotnetastgen-linux-arm
-            dotnetastgen-macos
-            dotnetastgen-macos-arm
-            dotnetastgen-win.exe
-            dotnetastgen-win-arm.exe
+            dotnetastgen-linux.zip
+            dotnetastgen-linux-arm.zip
+            dotnetastgen-macos.zip
+            dotnetastgen-macos-arm.zip
+            dotnetastgen-win.exe.zip
+            dotnetastgen-win-arm.exe.zip

--- a/DotNetAstGen/DotNetAstGen.csproj
+++ b/DotNetAstGen/DotNetAstGen.csproj
@@ -7,6 +7,7 @@
         <Nullable>enable</Nullable>
         <SelfContained>true</SelfContained>
         <PublishSingleFile>true</PublishSingleFile>
+        <PublishTrimmed>true</PublishTrimmed>
     </PropertyGroup>
 
     <ItemGroup>

--- a/DotNetAstGen/DotNetAstGen.csproj
+++ b/DotNetAstGen/DotNetAstGen.csproj
@@ -7,7 +7,6 @@
         <Nullable>enable</Nullable>
         <SelfContained>true</SelfContained>
         <PublishSingleFile>true</PublishSingleFile>
-        <PublishTrimmed>true</PublishTrimmed>
     </PropertyGroup>
 
     <ItemGroup>
@@ -15,6 +14,10 @@
       <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
       <PackageReference Include="Microsoft.CodeAnalysis" Version="4.8.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="release\" />
     </ItemGroup>
 
 </Project>

--- a/DotNetAstGen/Utils/MapSerializer.cs
+++ b/DotNetAstGen/Utils/MapSerializer.cs
@@ -1,19 +1,16 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Newtonsoft.Json.Linq;
-using System.Data;
-using System.Runtime.InteropServices;
-using DotNetAstGen.Utils;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
 
 namespace DotNetAstGen.Utils
 {
     public class MapSerializer
 
     {
-        private static ILogger? _logger = Program.LoggerFactory?.CreateLogger("MapSerializer");
-        
+        private static readonly ILogger? Logger = Program.LoggerFactory?.CreateLogger("MapSerializer");
+
         public static JArray ProcessSyntaxTokenList(SyntaxTokenList list)
         {
             JArray syntaxTokenList = new();


### PR DESCRIPTION
* Modified JsonResolver to use a mixture of techniques to include or exclude certain properties
* Found that `PublishTrimmed` breaks the program as the JSON serializer uses reflection
* Cleaned up some code
* Added `--output` argument with error handling

Resolves #5 
Resolves #6 
