### PR TITLE
Add operand property to allowed list

### DIFF
--- a/DotNetAstGen/SyntaxNodePropertiesResolver.cs
+++ b/DotNetAstGen/SyntaxNodePropertiesResolver.cs
@@ -17,7 +17,7 @@ namespace DotNetAstGen
             "Alias", "NamespaceOrType", "Arguments", "Expression", "Declaration", "ElementType", "Initializer", "Else",
             "Condition", "Statement", "Statements", "Variables", "WhenNotNull", "AllowsAnyExpression", "Expressions",
             "Modifiers", "ReturnType", "IsUnboundGenericName", "Default", "IsConst", "Parameters", "Types",
-            "ExplicitInterfaceSpecifier", "MetaData", "Kind", "AstRoot", "FileName", "Code"
+            "ExplicitInterfaceSpecifier", "MetaData", "Kind", "AstRoot", "FileName", "Code", "Operand"
         });
 
         private readonly List<string> _regexToAllow = new(new[]


### PR DESCRIPTION
We use a `allowProps` list to include a list of keys in the JSON output of the parser. This PR adds a key to the allowed properties. 