### PR TITLE
Include Accessors

### DIFF
--- a/DotNetAstGen/SyntaxNodePropertiesResolver.cs
+++ b/DotNetAstGen/SyntaxNodePropertiesResolver.cs
@@ -19,7 +19,7 @@ namespace DotNetAstGen
             "Modifiers", "ReturnType", "IsUnboundGenericName", "Default", "IsConst", "Types",
             "ExplicitInterfaceSpecifier", "MetaData", "Kind", "AstRoot", "FileName", "Code", "Operand", "Block",
             "Catches", "Finally", "Keyword", "Incrementors", "Sections", "Pattern", "Labels", "Elements" ,"WhenTrue",
-            "WhenFalse", "Initializers", "NameEquals", "Contents", "Attributes", "Designation"
+            "WhenFalse", "Initializers", "NameEquals", "Contents", "Attributes", "Designation", "Accessors"
         });
 
         private readonly List<string> _regexToAllow = new(new[]


### PR DESCRIPTION
Accessors are relevant for properties. Without them, we lose the `get; set;` declarations, i.e. GetAccessorDeclaration, SetAccessorDeclaration, resp.