### PR TITLE
Set DotNetAstGen.Test IsPublishable property to false

### DIFF
--- a/DotNetAstGen.Test/DotNetAstGen.Test.csproj
+++ b/DotNetAstGen.Test/DotNetAstGen.Test.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-
+        <IsPublishable>false</IsPublishable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 


### PR DESCRIPTION
Checking if this helps wrt #33. The only thing I could see interfering between 0.40.0 and 0.41.0 is that *Test.csproj now includes DotNetAstGen.csproj. Couldn't find anything concrete about this, but I'm wondering if being a dependency implies building ("publishing") it first and whether that could be interfering.