### PR TITLE
dotnet csproj instead of sln

### DIFF
--- a/build-with-version.sh
+++ b/build-with-version.sh
@@ -4,4 +4,4 @@ VERSION=${1:-$LATEST_TAG}
 
 echo "Running build with assigned version: $VERSION";
 
-dotnet build -c Release /p:Version=$VERSION /p:AssemblyVersion=$VERSION
+dotnet build ./DotNetAstGen/DotNetAstGen.csproj -c Release /p:Version=$VERSION /p:AssemblyVersion=$VERSION

--- a/build-with-version.sh
+++ b/build-with-version.sh
@@ -4,4 +4,4 @@ VERSION=${1:-$LATEST_TAG}
 
 echo "Running build with assigned version: $VERSION";
 
-dotnet build ./DotNetAstGen/DotNetAstGen.csproj -c Release /p:Version=$VERSION /p:AssemblyVersion=$VERSION
+dotnet build -c Release /p:Version=$VERSION /p:AssemblyVersion=$VERSION

--- a/publish-release.sh
+++ b/publish-release.sh
@@ -25,4 +25,4 @@ fi
 OUTPUT_PATH="$RELEASE_DIR/$OUTPUT_TARGET"
 TARGET="$OS-$ARCH"
 
-dotnet publish -c Release -r $TARGET -o $OUTPUT_PATH
+dotnet publish ./DotNetAstGen/DotNetAstGen.csproj -c Release -r $TARGET -o $OUTPUT_PATH


### PR DESCRIPTION
While #34 seemingly fixed #33, checking the CI logs I noticed this message:

> Warning: /usr/share/dotnet/sdk/8.0.407/Current/SolutionFile/ImportAfter/Microsoft.NET.Sdk.Solution.targets(36,5): warning NETSDK1194: The "--output" option isn't supported when building a solution. Specifying a solution-level output path results in all projects copying outputs to the same directory, which can lead to inconsistent builds. [/home/runner/work/DotNetAstGen/DotNetAstGen/DotNetAstGenNew.sln]

This matches my previous hypothesis that building from the solution builds both projects (DotNetAstGen.csproj and DotNetAstGen.Test.csproj), and given that their output folder is the same there are no guarantees they won't overwrite each other.

As such, a more permanent fix seems to entail specifying exactly the .csproj we intend to publish.